### PR TITLE
Expose hotkey binding frame

### DIFF
--- a/modules/bars/bars.lua
+++ b/modules/bars/bars.lua
@@ -495,7 +495,7 @@ DFRL:NewMod("Bars", 1, function()
 
             -- event handler
             if not self.hotkeyBindingFrame then
-                self.hotkeyBindingFrame = CreateFrame("Frame")
+                self.hotkeyBindingFrame = CreateFrame("Frame", "DFRL_HotkeyBinding")
                 self.hotkeyBindingFrame:RegisterEvent("UPDATE_BINDINGS")
                 self.hotkeyBindingFrame:SetScript("OnEvent", function()
                     UpdateHotkeys()


### PR DESCRIPTION
I'd like to be able to access this frame in my addon in order to prevent this expensive event from firing when I change many bindings at once.